### PR TITLE
feat: parse json strings

### DIFF
--- a/src/lib/Inspect.svelte
+++ b/src/lib/Inspect.svelte
@@ -29,6 +29,7 @@
     embedMedia,
     elementView,
     renderIf,
+    parseJson,
     ...props
   }: InspectProps = $props()
 
@@ -55,6 +56,7 @@
         embedMedia,
         elementView,
         renderIf,
+        parseJson,
       },
       globalOptions
     )

--- a/src/lib/components/Expandable.svelte
+++ b/src/lib/components/Expandable.svelte
@@ -10,6 +10,7 @@
   import CollapseButton from './CollapseButton.svelte'
   import Count from './Count.svelte'
   import Key from './Key.svelte'
+  import NodeNote from './NodeNote.svelte'
   import Tools from './Tools.svelte'
   import Type from './Type.svelte'
 
@@ -39,6 +40,7 @@
     path = [],
     showLength = true,
     children,
+    note,
     ...rest
   }: Props = $props()
 
@@ -104,7 +106,9 @@
       />
     {/if}
   </div>
-
+  {#if note && !previewLevel}
+    <NodeNote title={note.description}>{note.title}</NodeNote>
+  {/if}
   {#if !isKey}
     <Type {type} force={forceType} />
   {/if}

--- a/src/lib/components/NodeNote.svelte
+++ b/src/lib/components/NodeNote.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  type Props = {
+    children?: Snippet
+  } & HTMLAttributes<HTMLSpanElement>
+
+  let { children, ...rest }: Props = $props()
+</script>
+
+<span {...rest}>
+  {@render children?.()}
+</span>
+
+<style>
+  span {
+    font-family: var(--inspect-font);
+    font-size: 0.8em;
+    height: 1.5em;
+    line-height: 1.5em;
+    color: var(--red);
+    background-color: var(--bg);
+    outline: 1px solid var(--red);
+    padding-inline: 0.5em;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: all 150ms ease-in-out;
+    transform-origin: bottom center;
+  }
+</style>

--- a/src/lib/components/NodeNote.svelte
+++ b/src/lib/components/NodeNote.svelte
@@ -23,7 +23,7 @@
     background-color: var(--bg);
     outline: 1px solid var(--red);
     padding-inline: 0.5em;
-    cursor: pointer;
+    cursor: help;
     border-radius: 2px;
     transition: all 150ms ease-in-out;
     transform-origin: bottom center;

--- a/src/lib/components/StringView.svelte
+++ b/src/lib/components/StringView.svelte
@@ -4,6 +4,7 @@
   import type { TypeViewProps } from '../types.js'
   import { stringify } from '../util.js'
   import Expandable from './Expandable.svelte'
+  import Node from './Node.svelte'
   import OneLineView from './OneLineView.svelte'
   import StringValue from './StringValue.svelte'
 
@@ -13,6 +14,20 @@
   const options = useOptions()
 
   let isMultiLine = $derived(value.includes('\n'))
+
+  let parsedValue = $derived.by(() => {
+    const canBeValidJSON = value.startsWith('{') || value.startsWith('[')
+
+    if (options.value.parseJson && canBeValidJSON) {
+      try {
+        const p = JSON.parse(value)
+        return p as Record<string, unknown> | unknown[]
+      } catch {
+        return
+      }
+    }
+    return
+  })
 
   const IMAGE_EXTENSIONS = ['.gif', '.png', '.svg', '.jpg', '.jpeg', '.webp']
   const AUDIO_EXTENSIONS = ['.mp3', '.ogg', '.wav']
@@ -27,11 +42,18 @@
   )
 </script>
 
-{#if (isMultiLine || ((isImageUrl || isAudioUrl) && options.value.embedMedia)) && !previewLevel}
+{#if parsedValue}
+  <Node
+    value={parsedValue}
+    {path}
+    {key}
+    {...rest}
+    note={{ title: 'parsed', description: 'This value was parsed from a JSON string' }}
+  />
+{:else if (isMultiLine || ((isImageUrl || isAudioUrl) && options.value.embedMedia)) && !previewLevel}
   <Expandable
-    {...{ value, key, type, path }}
+    {...{ value, key, type, path, showKey }}
     length={value.length}
-    {showKey}
     keepPreviewOnExpand
     {...rest}
   >

--- a/src/lib/options.svelte.ts
+++ b/src/lib/options.svelte.ts
@@ -148,6 +148,7 @@ export type InspectOptions = {
    * Default `true`
    */
   renderIf: unknown
+  parseJson: boolean
 }
 
 const DEFAULT_OPTIONS: InspectOptions = {
@@ -170,6 +171,7 @@ const DEFAULT_OPTIONS: InspectOptions = {
   embedMedia: false,
   elementView: 'simple',
   renderIf: true,
+  parseJson: false,
 } as const
 
 export function mergeOptions(

--- a/src/lib/options.svelte.ts
+++ b/src/lib/options.svelte.ts
@@ -148,6 +148,11 @@ export type InspectOptions = {
    * Default `true`
    */
   renderIf: unknown
+  /**
+   * Try parsing strings that start with `'['` or `'{'` and display the parsed value
+   *
+   * Default `false`
+   */
   parseJson: boolean
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export type TypeViewProps<Value = unknown, Type = ValueType> = {
    * Force type indicator visibility for this node
    */
   forceType?: boolean
+  note?: { title: string; description: string }
 }
 
 export type CustomComponentPropsTransformFn<TComponent extends Component<any>> = (

--- a/src/routes/expand/+page.svelte
+++ b/src/routes/expand/+page.svelte
@@ -1,30 +1,21 @@
 <script lang="ts">
   import Inspect from '$lib/Inspect.svelte'
 
-  let data = JSON.parse(`{}`)
-  let show = $state(false)
-  let expandAll = $state(false)
+  let data = { a: `{}`, b: `[`, c: '[ "a", "b", "c", 1, 2, 3, true,false,null ]' }
+  let nestedData = {
+    a: `{}`,
+    b: `[`,
+    b2: `{`,
+    c: '[ "a", "b", "c", 1, 2, 3, true,false,null ]',
+    d: JSON.stringify(data),
+  }
+  let parseJson = $state(false)
 </script>
 
 <label>
-  show
-  <input type="checkbox" bind:checked={show} />
-</label>
-<label>
-  expand all
-  <input type="checkbox" bind:checked={expandAll} />
+  parse
+  <input type="checkbox" bind:checked={parseJson} />
 </label>
 
-{#if show}
-  <Inspect
-    borderless
-    value={data}
-    {expandAll}
-    showTools={false}
-    showPreview={false}
-    showLength={false}
-    showTypes={false}
-    flashOnUpdate={false}
-    noanimate={false}
-  />
-{/if}
+<Inspect value={data} {parseJson} />
+<Inspect value={JSON.stringify(nestedData, undefined, 2)} {parseJson} />


### PR DESCRIPTION
- New option / prop: `parseJson`
  - If `true`, string nodes will check if the string starts with `'{'` or `'['` and attempt to parse it as JSON and display the parsed value.
  - A note will be shown to indicate that an object or array is parsed from a string